### PR TITLE
minor fix in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ plugins:
 rules:
   # Plugins
   classes/space  : 2
-  classes/name   : [2, "class", "name"]
+  classes/name   : [2, "class", "method"]
 ```
 
 ## License


### PR DESCRIPTION
Corrected option for `classes/name`: it's "method", not "name"
